### PR TITLE
Put dll in /lib folder in NuGet package so it's automatically added when installing package

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -70,7 +70,7 @@ Target "CreateNuget" (fun _ ->
                 "MsgPack.Cli", "0.6.5"
             ]
             Files = [
-                (@"DoubleCache.*", None, None)
+                (@"DoubleCache.*", Some @"lib\net46", None)
             ]
         }) 
         "DoubleCache.nuspec"


### PR DESCRIPTION
Hi Harald,

This is to fix a problem with the generated nuget package. In the [NuGet documentation](https://docs.nuget.org/create/creating-and-publishing-a-package#from-a-convention-based-working-directory), assemblies added to a '/lib/<version>' folder will be added as assembly references when the package is installed. This is the typical behavior when installing a nuget package.

What happens currently when installing DoubleCache is the package is installed but no reference to `DoubleCache.dll` is added to the project. I have to manually add the reference to the .dll every time I install or update the package.

Related to this, would you be open to re-targeting DoubleCache for .net 4.5? No C# 6 features are currently being used in DoubleCache. The .Net framework versions are backwards compatible, but not fowards compatible, so you could still use this from a .net 4.6 project. I would like to use DoubleCache on a project that's on .net 4.5 for the foreseeable future.

If you'd prefer not to re-target 4.5, I could probably make a change to [multi-target both 4.5 and 4.6](http://shazwazza.com/post/multi-targeting-a-single-net-project-to-build-for-different-framework-versions/), but it would take some work.