### PR TITLE
Set minimum version for StackExchange.Redis to 1.0.488

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -66,7 +66,7 @@ Target "CreateNuget" (fun _ ->
             Version = version
             Publish = false
             Dependencies = [
-                            "StackExchange.Redis", "1.0"
+                            "StackExchange.Redis", "1.0.488"
                             "MsgPack.Cli", "0.6.5"
             ]
             Files = [


### PR DESCRIPTION
When it was set to 1.0, NuGet was downloading version 1.0.187 which is from
March, 2014; before StackExchange.Redis had the IConnectionMultiplexer
interface.