### PR TITLE
Added synchronous versions of Get calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,24 @@ The ICacheAside interface is the main part of DoubleCache, all variants relies o
 public interface ICacheAside
   {
     void Add<T>(string key, T item);
-    
+    void Add<T>(string key, T item, TimeSpan? timeToLive);
+
+    T Get<T>(string key, Func<T> dataRetriever) where T : class;
+    T Get<T>(string key, Func<T> dataRetriever, TimeSpan? timeToLive) where T : class;
+
+    object Get(string key, Type type, Func<object> dataRetriever);
+    object Get(string key, Type type, Func<object> dataRetriever, TimeSpan? timeToLive);
+
     Task<T> GetAsync<T>(string key, Func<Task<T>> dataRetriever) where T : class;
+    Task<T> GetAsync<T>(string key, Func<Task<T>> dataRetriever, TimeSpan? timeToLive) where T : class;
+
     Task<object> GetAsync(string key, Type type, Func<Task<object>> dataRetriever);
+    Task<object> GetAsync(string key, Type type, Func<Task<object>> dataRetriever, TimeSpan? timeToLive);
+
+    void Remove(string key);
   }
 ```
-The Add method is implemented with fire and forget, hence it does not need to be Async as this is handled by the Stackexchange.Redis client. 
+The Add and remove methods are implemented with fire and forget, hence it does not need to be Async as this is handled by the StackExchange.Redis client.
 
 DoubleCache comes with the following implementations of this interface
 * LocalCache.MemCache - using System.Runtime.Memory

--- a/build.fsx
+++ b/build.fsx
@@ -12,7 +12,7 @@ let nugetDir = "./nuget"
 let references  = !! "source/DoubleCache/*.csproj"
 let testReferences = !! "source/DoubleCacheTests/*.csproj"    
 
-let version = "1.2.1"
+let version = "1.3.0"
 let commitHash = Information.getCurrentSHA1(".")
 
 let projectName = "DoubleCache"

--- a/source/DoubleCache/DoubleCache.cs
+++ b/source/DoubleCache/DoubleCache.cs
@@ -5,8 +5,8 @@ namespace DoubleCache
 {
     public class DoubleCache : ICacheAside 
     {
-        private ICacheAside _localCache;
-        private ICacheAside _remoteCache;
+        private readonly ICacheAside _localCache;
+        private readonly ICacheAside _remoteCache;
            
         public DoubleCache(ICacheAside localCache,ICacheAside remoteCache)
         {
@@ -24,6 +24,27 @@ namespace DoubleCache
         {
             _localCache.Add(key, item, timeToLive);
             _remoteCache.Add(key, item, timeToLive);
+        }
+
+        public T Get<T>(string key, Func<T> dataRetriever) where T : class
+        {
+            return _localCache.Get(key, () => _remoteCache.Get(key, dataRetriever));
+        }
+
+        public T Get<T>(string key, Func<T> dataRetriever, TimeSpan? timeToLive) where T : class
+        {
+            return _localCache.Get(key, () => _remoteCache.Get(key, dataRetriever, timeToLive), timeToLive);
+
+        }
+
+        public object Get(string key, Type type, Func<object> dataRetriever)
+        {
+            return _localCache.Get(key, type, () => _remoteCache.Get(key, type, dataRetriever));
+        }
+
+        public object Get(string key, Type type, Func<object> dataRetriever, TimeSpan? timeToLive)
+        {
+            return _localCache.Get(key, type, () => _remoteCache.Get(key, type, dataRetriever, timeToLive), timeToLive);
         }
 
         public Task<object> GetAsync(string key, Type type, Func<Task<object>> dataRetriever)

--- a/source/DoubleCache/ICacheAside.cs
+++ b/source/DoubleCache/ICacheAside.cs
@@ -8,6 +8,12 @@ namespace DoubleCache
         void Add<T>(string key, T item);
         void Add<T>(string key, T item, TimeSpan? timeToLive);
 
+        T Get<T>(string key, Func<T> dataRetriever) where T : class;
+        T Get<T>(string key, Func<T> dataRetriever, TimeSpan? timeToLive) where T : class;
+
+        object Get(string key, Type type, Func<object> dataRetriever);
+        object Get(string key, Type type, Func<object> dataRetriever, TimeSpan? timeToLive);
+
         Task<T> GetAsync<T>(string key, Func<Task<T>> dataRetriever) where T : class;
         Task<T> GetAsync<T>(string key, Func<Task<T>> dataRetriever, TimeSpan? timeToLive) where T : class;
 

--- a/source/DoubleCache/SubscribingCache.cs
+++ b/source/DoubleCache/SubscribingCache.cs
@@ -6,9 +6,9 @@ namespace DoubleCache
 {
     public class SubscribingCache : ICacheAside
     {
-        private ICacheAside _cache;
-        private ICacheSubscriber _cacheSubscriber;
-        private ConcurrentDictionary<string, Type> _knownTypes;
+        private readonly ICacheAside _cache;
+        private readonly ICacheSubscriber _cacheSubscriber;
+        private readonly ConcurrentDictionary<string, Type> _knownTypes;
 
         public SubscribingCache(ICacheAside cache, ICacheSubscriber cacheSubscriber)
         {
@@ -22,12 +22,32 @@ namespace DoubleCache
 
         public void Add<T>(string key, T item)
         {
-            _cache.Add<T>(key, item);
+            _cache.Add(key, item);
         }
 
         public void Add<T>(string key, T item, TimeSpan? timeToLive)
         {
-            _cache.Add<T>(key, item, timeToLive);
+            _cache.Add(key, item, timeToLive);
+        }
+
+        public T Get<T>(string key, Func<T> dataRetriever) where T : class
+        {
+            return _cache.Get(key, dataRetriever);
+        }
+
+        public T Get<T>(string key, Func<T> dataRetriever, TimeSpan? timeToLive) where T : class
+        {
+            return _cache.Get(key, dataRetriever, timeToLive);
+        }
+
+        public object Get(string key, Type type, Func<object> dataRetriever)
+        {
+            return _cache.Get(key, type, dataRetriever);
+        }
+
+        public object Get(string key, Type type, Func<object> dataRetriever, TimeSpan? timeToLive)
+        {
+            return _cache.Get(key, type, dataRetriever, timeToLive);
         }
 
         public Task<object> GetAsync(string key, Type type, Func<Task<object>> dataRetriever)
@@ -59,7 +79,7 @@ namespace DoubleCache
             var remoteItem = await _cacheSubscriber.GetAsync(e.Key, _knownTypes.GetOrAdd(e.Type, Type.GetType(e.Type)));
 
             if (e.SpecificTimeToLive != null)
-                Add(e.Key, remoteItem,e.SpecificTimeToLive._timeToLive);
+                Add(e.Key, remoteItem, e.SpecificTimeToLive._timeToLive);
             else
                 Add(e.Key, remoteItem);
         }

--- a/source/DoubleCacheTests/DoubleCacheTests.cs
+++ b/source/DoubleCacheTests/DoubleCacheTests.cs
@@ -8,10 +8,10 @@ namespace DoubleCacheTests
 {
     public class DoubleCacheTests
     {
-        ICacheAside _local;
-        ICacheAside _remote;
+        private readonly ICacheAside _local;
+        private readonly ICacheAside _remote;
 
-        DoubleCache.DoubleCache _doubleCache;
+        private readonly DoubleCache.DoubleCache _doubleCache;
 
         public DoubleCacheTests()
         {
@@ -43,6 +43,42 @@ namespace DoubleCacheTests
         }
 
         [Fact]
+        public void Get_CalledOnLocal()
+        {
+            _doubleCache.Get("A", typeof(string), null);
+
+            A.CallTo(() => _local.Get("A", A<Type>.Ignored, A<Func<object>>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => _remote.Get("A", A<Type>.Ignored, A<Func<object>>.Ignored)).MustNotHaveHappened();
+        }
+
+        [Fact]
+        public void Get_WithTimeToLive_CalledOnLocal()
+        {
+            _doubleCache.Get("A", typeof(string), null, TimeSpan.FromSeconds(1));
+
+            A.CallTo(() => _local.Get("A", A<Type>.Ignored, A<Func<object>>.Ignored, TimeSpan.FromSeconds(1))).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => _remote.Get("A", A<Type>.Ignored, A<Func<object>>.Ignored, TimeSpan.FromSeconds(1))).MustNotHaveHappened();
+        }
+
+        [Fact]
+        public void GetGeneric_CalledOnLocal()
+        {
+            _doubleCache.Get<string>("A", null);
+
+            A.CallTo(() => _local.Get("A", A<Func<string>>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => _remote.Get("A", A<Func<string>>.Ignored)).MustNotHaveHappened();
+        }
+
+        [Fact]
+        public void GetGeneric_WithTimeToLive_CalledOnLocal()
+        {
+            _doubleCache.Get<string>("A", null, TimeSpan.FromSeconds(1));
+
+            A.CallTo(() => _local.Get("A", A<Func<string>>.Ignored, TimeSpan.FromSeconds(1))).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => _remote.Get("A", A<Func<string>>.Ignored)).MustNotHaveHappened();
+        }
+
+        [Fact]
         public async Task GetAsync_CalledOnLocal()
         {
             await _doubleCache.GetAsync("A", typeof(string), null);
@@ -65,8 +101,8 @@ namespace DoubleCacheTests
         {
             await _doubleCache.GetAsync<string>("A", null);
 
-            A.CallTo(() => _local.GetAsync<string>("A",  A<Func<Task<string>>>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
-            A.CallTo(() => _remote.GetAsync<string>("A", A<Func<Task<string>>>.Ignored)).MustNotHaveHappened();
+            A.CallTo(() => _local.GetAsync("A",  A<Func<Task<string>>>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => _remote.GetAsync("A", A<Func<Task<string>>>.Ignored)).MustNotHaveHappened();
         }
 
         [Fact]
@@ -74,8 +110,8 @@ namespace DoubleCacheTests
         {
             await _doubleCache.GetAsync<string>("A", null, TimeSpan.FromSeconds(1));
 
-            A.CallTo(() => _local.GetAsync<string>("A", A<Func<Task<string>>>.Ignored, TimeSpan.FromSeconds(1))).MustHaveHappened(Repeated.Exactly.Once);
-            A.CallTo(() => _remote.GetAsync<string>("A", A<Func<Task<string>>>.Ignored)).MustNotHaveHappened();
+            A.CallTo(() => _local.GetAsync("A", A<Func<Task<string>>>.Ignored, TimeSpan.FromSeconds(1))).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => _remote.GetAsync("A", A<Func<Task<string>>>.Ignored)).MustNotHaveHappened();
         }
 
         [Fact]

--- a/source/DoubleCacheTests/IntegrationTests/CacheFactoryTests.cs
+++ b/source/DoubleCacheTests/IntegrationTests/CacheFactoryTests.cs
@@ -11,14 +11,14 @@ namespace DoubleCacheTests.IntegrationTests
     public class CacheFactoryTests
     {
         [Fact]
-        public void CreatesSyncedCache_ReturnsCacheObject()
+        public void CreatePubSubDoubleCache_ReturnsCacheObject()
         {
             var connection = A.Fake<IConnectionMultiplexer>();
             var serializer = A.Fake<IItemSerializer>();
 
-            var cache1 = CacheFactory.CreatePubSubDoubleCache(connection, serializer);
+            var cache = CacheFactory.CreatePubSubDoubleCache(connection, serializer);
 
-            cache1.ShouldBeOfType<DoubleCache.DoubleCache>();
+            cache.ShouldBeOfType<DoubleCache.DoubleCache>();
         }
     }
 }

--- a/source/DoubleCacheTests/IntegrationTests/CacheImplementationTests.cs
+++ b/source/DoubleCacheTests/IntegrationTests/CacheImplementationTests.cs
@@ -14,6 +14,112 @@ namespace DoubleCacheTests.IntegrationTests
 
 
         [Fact]
+        public void Get_ExistingValue_ReturnsValue()
+        {
+            _cacheImplementation.Add(_key, "A");
+
+            var result = _cacheImplementation.Get<string>(_key, null);
+
+            result.ShouldBe("A");
+        }
+
+        [Fact]
+        public void Get_WithTimeToLive_ExistingValue_ReturnsValue()
+        {
+            _cacheImplementation.Add(_key, "A");
+
+            var result = _cacheImplementation.Get<string>(_key, null, TimeSpan.FromSeconds(1));
+
+            result.ShouldBe("A");
+        }
+
+        [Fact]
+        public void GetGeneric_NoValue_CallsMethod()
+        {
+            var func = A.Fake<Func<string>>();
+
+            _cacheImplementation.Get(_key, func);
+
+            A.CallTo(() => func.Invoke()).MustHaveHappened(Repeated.Exactly.Once);
+        }
+
+        [Fact]
+        public void GetGeneric_WithTimeToLive_NoValue_CallsMethod()
+        {
+            var func = A.Fake<Func<string>>();
+
+            _cacheImplementation.Get(_key, func, TimeSpan.FromSeconds(1));
+
+            A.CallTo(() => func.Invoke()).MustHaveHappened(Repeated.Exactly.Once);
+        }
+
+        [Fact]
+        public void GetGeneric_NoValue_CachePopulated()
+        {
+            var func = A.Fake<Func<string>>();
+
+            A.CallTo(() => func.Invoke()).Returns("A");
+
+            var result = _cacheImplementation.Get(_key, func);
+
+            result.ShouldBe("A");
+        }
+
+        [Fact]
+        public void GetUntyped_ExistingValue_ReturnsValue()
+        {
+            _cacheImplementation.Add(_key, "A");
+
+            var result = _cacheImplementation.Get(_key, typeof(string), null);
+
+            result.ShouldBe("A");
+        }
+
+        [Fact]
+        public void GetUntyped_WithTimeToLive_ExistingValue_ReturnsValue()
+        {
+            _cacheImplementation.Add(_key, "A");
+
+            var result = _cacheImplementation.Get(_key, typeof(string), null, TimeSpan.FromSeconds(1));
+
+            result.ShouldBe("A");
+        }
+
+        [Fact]
+        public void GetUntyped_NoValue_CallsMethod()
+        {
+            var func = A.Fake<Func<object>>();
+
+            _cacheImplementation.Get(_key, typeof(string), func);
+
+            A.CallTo(() => func.Invoke()).MustHaveHappened(Repeated.Exactly.Once);
+        }
+
+        [Fact]
+        public void GetUntyped_NoValue_CachePopulated()
+        {
+            var func = A.Fake<Func<object>>();
+
+            A.CallTo(() => func.Invoke()).Returns("A");
+
+            var result = _cacheImplementation.Get(_key, typeof(string), func);
+
+            result.ShouldBe("A");
+        }
+
+        [Fact]
+        public void GetUntyped_WithTimeToLive_NoValue_CachePopulated()
+        {
+            var func = A.Fake<Func<object>>();
+
+            A.CallTo(() => func.Invoke()).Returns("A");
+
+            var result = _cacheImplementation.Get(_key, typeof(string), func, TimeSpan.FromSeconds(1));
+
+            result.ShouldBe("A");
+        }
+
+        [Fact]
         public async Task GetAsync_ExistingValue_ReturnsValue()
         {
             _cacheImplementation.Add(_key, "A");
@@ -38,7 +144,7 @@ namespace DoubleCacheTests.IntegrationTests
         {
             var func = A.Fake<Func<Task<string>>>();
 
-            var result = await _cacheImplementation.GetAsync(_key, func);
+            await _cacheImplementation.GetAsync(_key, func);
 
             A.CallTo(() => func.Invoke()).MustHaveHappened(Repeated.Exactly.Once);
         }
@@ -48,7 +154,7 @@ namespace DoubleCacheTests.IntegrationTests
         {
             var func = A.Fake<Func<Task<string>>>();
 
-            var result = await _cacheImplementation.GetAsync(_key, func, TimeSpan.FromSeconds(1));
+            await _cacheImplementation.GetAsync(_key, func, TimeSpan.FromSeconds(1));
 
             A.CallTo(() => func.Invoke()).MustHaveHappened(Repeated.Exactly.Once);
         }
@@ -90,7 +196,7 @@ namespace DoubleCacheTests.IntegrationTests
         {
             var func = A.Fake<Func<Task<object>>>();
 
-            var result = await _cacheImplementation.GetAsync(_key, typeof(string), func);
+            await _cacheImplementation.GetAsync(_key, typeof(string), func);
 
             A.CallTo(() => func.Invoke()).MustHaveHappened(Repeated.Exactly.Once);
         }

--- a/source/DoubleCacheTests/SubscribingCacheTests.cs
+++ b/source/DoubleCacheTests/SubscribingCacheTests.cs
@@ -8,9 +8,9 @@ namespace DoubleCacheTests
 {
     public class SubscribingCacheTests
     {
-        ICacheAside _decoratedCache;
-        ICacheSubscriber _subscriber;
-        ICacheAside _subscribingCache;
+        private readonly ICacheAside _decoratedCache;
+        private readonly ICacheSubscriber _subscriber;
+        private readonly ICacheAside _subscribingCache;
 
         public SubscribingCacheTests()
         {
@@ -36,6 +36,38 @@ namespace DoubleCacheTests
         }
 
         [Fact]
+        public void Get_CallsThrough()
+        {
+            _subscribingCache.Get("a", typeof(string), null);
+            A.CallTo(() => _decoratedCache.Get("a", typeof(string), A<Func<object>>._))
+                .MustHaveHappened(Repeated.Exactly.Once);
+        }
+
+        [Fact]
+        public void Get_WithTimeToLive_CallsThrough()
+        {
+            _subscribingCache.Get("a", typeof(string), null, TimeSpan.FromSeconds(1));
+            A.CallTo(() => _decoratedCache.Get("a", typeof(string), A<Func<object>>._, TimeSpan.FromSeconds(1)))
+                .MustHaveHappened(Repeated.Exactly.Once);
+        }
+
+        [Fact]
+        public void GetGeneric_CallsThrough()
+        {
+            _subscribingCache.Get("a", A.Fake<Func<string>>());
+            A.CallTo(() => _decoratedCache.Get("a", A<Func<string>>._))
+                .MustHaveHappened(Repeated.Exactly.Once);
+        }
+
+        [Fact]
+        public void GetGeneric_WithTimeToLive_CallsThrough()
+        {
+            _subscribingCache.Get("a", A.Fake<Func<string>>(), TimeSpan.FromSeconds(1));
+            A.CallTo(() => _decoratedCache.Get("a", A<Func<string>>._, TimeSpan.FromSeconds(1)))
+                .MustHaveHappened(Repeated.Exactly.Once);
+        }
+
+        [Fact]
         public async Task GetAsync_CallsThrough()
         {
             await _subscribingCache.GetAsync("a", typeof(string), null);
@@ -58,7 +90,7 @@ namespace DoubleCacheTests
             A.CallTo(() => _decoratedCache.GetAsync("a", A<Func<Task<string>>>._))
                 .MustHaveHappened(Repeated.Exactly.Once);
         }
-
+        
         [Fact]
         public async Task GetAsyncGeneric_WithTimeToLive_CallsThrough()
         {


### PR DESCRIPTION
Hello Harald,

I added synchronous versions of Get for those of us that are unable to use async for whatever reason. In my case, I have a pretty extensive codebase that is written synchronously and cannot yet be converted to async. For now, I have put in [a hack](https://msdn.microsoft.com/en-us/magazine/mt238404.aspx) to allow calling async methods in a synchronous context but it is fragile and there is a potential for deadlocks.

I did not add any new functionality to the sample because the new methods work exactly the same as the asynchronous ones.