### PR TITLE
Fixed thrown exception when calling dataRetriever after receiving a CacheUpdated message

### DIFF
--- a/source/DoubleCache/Redis/RedisSubscriber.cs
+++ b/source/DoubleCache/Redis/RedisSubscriber.cs
@@ -10,7 +10,6 @@ namespace DoubleCache.Redis
     {
         private ICacheAside _remoteCache;
         private IItemSerializer _itemSerializer;
-        private ConcurrentDictionary<string, Type> _knownTypes;
         private string _clientName;
 
         public event EventHandler<CacheUpdateNotificationArgs> CacheUpdate;
@@ -23,7 +22,6 @@ namespace DoubleCache.Redis
             _remoteCache = remoteCache;
             _itemSerializer = itemSerializer;
             _clientName = connection.ClientName;
-            _knownTypes = new ConcurrentDictionary<string, Type>();
         }
 
         private void CacheUpdated(RedisChannel channel, RedisValue message)
@@ -34,8 +32,7 @@ namespace DoubleCache.Redis
             if (updateNotification.ClientName.Equals(_clientName))
                 return;
 
-            if (CacheUpdate != null)
-                CacheUpdate(this, updateNotification);
+            CacheUpdate?.Invoke(this, updateNotification);
         }
 
         private void CacheDeleted(RedisChannel channel, RedisValue message)
@@ -45,13 +42,12 @@ namespace DoubleCache.Redis
             if (deleteNotification.ClientName.Equals(_clientName))
                 return;
 
-            if (CacheDelete != null)
-                CacheDelete(this, deleteNotification);
+            CacheDelete?.Invoke(this, deleteNotification);
         }
 
         public Task<object> GetAsync(string key, Type type)
         {
-            return _remoteCache.GetAsync(key, type,() => null);
+            return _remoteCache.GetAsync(key, type,() => Task.FromResult<object>(null));
         }
     }
 }

--- a/source/DoubleCache/SubscribingCache.cs
+++ b/source/DoubleCache/SubscribingCache.cs
@@ -78,10 +78,13 @@ namespace DoubleCache
         {
             var remoteItem = await _cacheSubscriber.GetAsync(e.Key, _knownTypes.GetOrAdd(e.Type, Type.GetType(e.Type)));
 
-            if (e.SpecificTimeToLive != null)
-                Add(e.Key, remoteItem, e.SpecificTimeToLive._timeToLive);
-            else
-                Add(e.Key, remoteItem);
+            if (remoteItem != null)
+            {
+                if (e.SpecificTimeToLive != null)
+                    Add(e.Key, remoteItem, e.SpecificTimeToLive._timeToLive);
+                else
+                    Add(e.Key, remoteItem);
+            }
         }
 
         private void OnCacheDelete(object sender, CacheUpdateNotificationArgs e)

--- a/source/DoubleCacheTests/SubscribingCacheTests.cs
+++ b/source/DoubleCacheTests/SubscribingCacheTests.cs
@@ -133,6 +133,17 @@ namespace DoubleCacheTests
         }
 
         [Fact]
+        public async Task SubscriberUpdater_NullReturned_DoesNotAddToCache()
+        {
+            A.CallTo(() => _subscriber.GetAsync("a", A<Type>.Ignored)).Returns(null);
+            _subscriber.CacheUpdate += Raise.With(this, new CacheUpdateNotificationArgs { Key = "a", Type = typeof(string).AssemblyQualifiedName, SpecificTimeToLive = new TimeToLive(TimeSpan.FromMinutes(1)) });
+
+            await Task.Delay(TimeSpan.FromSeconds(1));
+            A.CallTo(() => _decoratedCache.Add<object>("a", "b", TimeSpan.FromMinutes(1)))
+                .MustNotHaveHappened();
+        }
+
+        [Fact]
         public async Task SubscriberDelete_ItemDelete()
         {
             _subscriber.CacheDelete += Raise.With(this, new CacheUpdateNotificationArgs { Key = "a" });


### PR DESCRIPTION
Hi Harald,

This bug was found when our IIS instances were continually restarting. For
some reason CacheUpdated messages were being sent out but the data was not
in Redis. In that case, the null dataRetriever was being called which would
throw a NullReferenceException. Since it's running in an EventHandler in
the background it wasn't being caught and the process would crash. Changed
the null Task to a Task that returns null so we don't throw an exception.

It would be great if you could look at this ASAP as it caused us some problems in production.

Thanks,
Clay