### PR TITLE
Multiple application subscribers on same machine not taking actions on notifications

### DIFF
--- a/source/DoubleCache/Redis/RedisPublisher.cs
+++ b/source/DoubleCache/Redis/RedisPublisher.cs
@@ -9,16 +9,18 @@ namespace DoubleCache.Redis
     {
         private IConnectionMultiplexer _connection;
         private IItemSerializer _itemSerializer;
+        private string _clientName;
 
         public RedisPublisher(IConnectionMultiplexer connection, IItemSerializer itemSerializer)
         {
             _connection = connection;
             _itemSerializer = itemSerializer;
+            _clientName = connection.ClientName + "." + System.AppDomain.CurrentDomain.FriendlyName;
         }
 
         public void NotifyUpdate(string key, string type)
         {
-            var data = _itemSerializer.Serialize(new CacheUpdateNotificationArgs { Key = key, Type = type, ClientName = _connection.ClientName });
+            var data = _itemSerializer.Serialize(new CacheUpdateNotificationArgs { Key = key, Type = type, ClientName = _clientName });
            _connection.GetSubscriber().Publish(
                 "cacheUpdate",
                 data,
@@ -30,7 +32,7 @@ namespace DoubleCache.Redis
             var data = _itemSerializer.Serialize(new CacheUpdateNotificationArgs {
                 Key = key,
                 Type = type,
-                ClientName = _connection.ClientName,
+                ClientName = _clientName,
                 SpecificTimeToLive = new TimeToLive(specificTimeToLive)});
 
             _connection.GetSubscriber().Publish(
@@ -43,7 +45,8 @@ namespace DoubleCache.Redis
         {
             var data = _itemSerializer.Serialize(new CacheUpdateNotificationArgs { 
                 Key = key,
-                ClientName = _connection.ClientName});
+                ClientName = _clientName
+            });
             _connection.GetSubscriber().Publish(
                 "cacheDelete",
                 data,

--- a/source/DoubleCache/Redis/RedisSubscriber.cs
+++ b/source/DoubleCache/Redis/RedisSubscriber.cs
@@ -21,7 +21,7 @@ namespace DoubleCache.Redis
             connection.GetSubscriber().Subscribe("cacheDelete", CacheDeleted);
             _remoteCache = remoteCache;
             _itemSerializer = itemSerializer;
-            _clientName = connection.ClientName;
+            _clientName = connection.ClientName + "." + System.AppDomain.CurrentDomain.FriendlyName;
         }
 
         private void CacheUpdated(RedisChannel channel, RedisValue message)

--- a/source/DoubleCacheTests/PublisherTests.cs
+++ b/source/DoubleCacheTests/PublisherTests.cs
@@ -13,6 +13,7 @@ namespace DoubleCacheTests
         private IConnectionMultiplexer _connection;
         private IItemSerializer _serializer;
         private ISubscriber _subscriber;
+        private string _expectedClientName;
 
         private ICachePublisher publisher;
 
@@ -21,6 +22,7 @@ namespace DoubleCacheTests
             _connection = A.Fake<IConnectionMultiplexer>();
             _serializer = A.Fake<IItemSerializer>();
             _subscriber = A.Fake<ISubscriber>();
+            _expectedClientName = "C." + System.AppDomain.CurrentDomain.FriendlyName;
 
             A.CallTo(() => _connection.GetSubscriber(null)).Returns(_subscriber);
             A.CallTo(() => _connection.ClientName).Returns("C");
@@ -35,7 +37,7 @@ namespace DoubleCacheTests
             publisher.NotifyUpdate("A", "B");
 
             A.CallTo(() => _serializer.Serialize(
-                    A<CacheUpdateNotificationArgs>.That.Matches(args => args.Key == "A" && args.Type == "B" && args.ClientName == "C")))
+                    A<CacheUpdateNotificationArgs>.That.Matches(args => args.Key == "A" && args.Type == "B" && args.ClientName == _expectedClientName)))
                 .MustHaveHappened(Repeated.Exactly.Once);
         }
 
@@ -45,7 +47,7 @@ namespace DoubleCacheTests
             publisher.NotifyDelete("A");
 
             A.CallTo(() => _serializer.Serialize(
-                    A<CacheUpdateNotificationArgs>.That.Matches(args => args.Key == "A" && args.ClientName == "C")))
+                    A<CacheUpdateNotificationArgs>.That.Matches(args => args.Key == "A" && args.ClientName == _expectedClientName)))
                 .MustHaveHappened(Repeated.Exactly.Once);
         }
 

--- a/source/DoubleCacheTests/RedisSubscriberTests.cs
+++ b/source/DoubleCacheTests/RedisSubscriberTests.cs
@@ -16,12 +16,14 @@ namespace DoubleCacheTests
         private ICacheAside _remoteCache;
         private IItemSerializer _itemSerializer;
         private IConnectionMultiplexer _connection;
+        private string _expectedClientName;
 
         public RedisSubscriberTests()
         {
             _subscriber = A.Fake<ISubscriber>();
             _remoteCache = A.Fake<ICacheAside>();
             _itemSerializer = A.Fake<IItemSerializer>();
+            _expectedClientName = "A." + System.AppDomain.CurrentDomain.FriendlyName;
 
             _connection = A.Fake<IConnectionMultiplexer>();
             A.CallTo(() => _connection.GetSubscriber(A<object>._)).Returns(_subscriber);
@@ -86,7 +88,7 @@ namespace DoubleCacheTests
 
             var eventHandler = A.Fake<EventHandler<CacheUpdateNotificationArgs>>();
 
-            A.CallTo(() => _itemSerializer.Deserialize<CacheUpdateNotificationArgs>(A<byte[]>._)).Returns(new CacheUpdateNotificationArgs() { ClientName ="A" });
+            A.CallTo(() => _itemSerializer.Deserialize<CacheUpdateNotificationArgs>(A<byte[]>._)).Returns(new CacheUpdateNotificationArgs() { ClientName = _expectedClientName });
 
             var cacheSubscriber = new RedisSubscriber(_connection, _remoteCache, _itemSerializer);
 
@@ -101,7 +103,7 @@ namespace DoubleCacheTests
         [Theory]
         [InlineData("cacheUpdate")]
         [InlineData("cacheDelete")]
-        public void OnMessage_SameClientName_EventNotTriggered(string channelName)
+        public void OnMessage_SameClientNameSameApplicationName_EventNotTriggered(string channelName)
         {
             Action<RedisChannel, RedisValue> method = null;
 
@@ -113,7 +115,7 @@ namespace DoubleCacheTests
 
             var eventHandler = A.Fake<EventHandler<CacheUpdateNotificationArgs>>();
 
-            A.CallTo(() => _itemSerializer.Deserialize<CacheUpdateNotificationArgs>(A<byte[]>._)).Returns(new CacheUpdateNotificationArgs() { ClientName = "A" });
+            A.CallTo(() => _itemSerializer.Deserialize<CacheUpdateNotificationArgs>(A<byte[]>._)).Returns(new CacheUpdateNotificationArgs() { ClientName = _expectedClientName });
 
             var cacheSubscriber = new RedisSubscriber(_connection, _remoteCache, _itemSerializer);
 


### PR DESCRIPTION
Ran into an issue on our web servers that run many applications that are both publisher and subscribers. For instance, our API updates the cache and the Web application is a subscriber to the events, but ignores them because it's on the same machine. This will overcome that without removing the optimization of not performing updates and deletes on the publishing application.